### PR TITLE
chore: update bun.lock with configVersion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "blog",


### PR DESCRIPTION
## Summary

- Update `bun.lock` to include `configVersion: 0` field in lockfile metadata

## Changes

This change updates the bun lockfile to include the `configVersion` field, which is used by bun to track the configuration schema version of the lockfile format. This ensures compatibility with the current version of bun.